### PR TITLE
MOX-20344 change default SSL verification to enabled

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -552,8 +552,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
                     curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
                 }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                // default to host and peer verification on
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
             }
         }
 


### PR DESCRIPTION
SSL Peer and Host verification was being turned off by default.  Update apiClient template (mustache) to enable SSL verification by default.
